### PR TITLE
crafting menu fuzzy searching

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -177,7 +177,7 @@ namespace Content.Client.Construction.UI
 
                 if (!string.IsNullOrEmpty(search))
                 {
-                    if ( !string.IsNullOrEmpty(recipe.FuzzyName) ? CheckFuzzySearch(recipe.FuzzyName,search) : !recipe.Name.ToLowerInvariant().Contains(search.Trim().ToLowerInvariant()))
+                    if ( !CheckFuzzySearch(string.IsNullOrEmpty(recipe.FuzzyName) ? recipe.Name :recipe.FuzzyName,search) )
                         continue;
                 }
 

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -146,6 +146,17 @@ namespace Content.Client.Construction.UI
             PopulateInfo(_selected);
         }
 
+		private bool CheckFuzzySearch(string hostfield,string searchtext){
+			int matchedtokens=0;
+			char[] str_seps={' ',':','.',',','/'}; //flatten punctuation.
+			string[] searchtokens = searchtext.Split(str_seps); //turn the search into tokens
+
+			foreach (string stoken in searchtokens){
+				if(hostfield.Contains(stoken,StringComparison.OrdinalIgnoreCase)) matchedtokens++; //thanks chatGPT for helping me.
+			}
+			return matchedtokens==searchtokens.Length;
+		}	
+
         private void OnViewPopulateRecipes(object? sender, (string search, string catagory) args)
         {
             var (search, category) = args;
@@ -166,7 +177,7 @@ namespace Content.Client.Construction.UI
 
                 if (!string.IsNullOrEmpty(search))
                 {
-                    if (!recipe.Name.ToLowerInvariant().Contains(search.Trim().ToLowerInvariant()))
+                    if ( !string.IsNullOrEmpty(recipe.FuzzyName) ? CheckFuzzySearch(recipe.FuzzyName,search) : !recipe.Name.ToLowerInvariant().Contains(search.Trim().ToLowerInvariant()))
                         continue;
                 }
 

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
@@ -22,6 +22,12 @@ public sealed partial class ConstructionPrototype : IPrototype
     /// </summary>
     [DataField("name")]
     public string Name = string.Empty;
+	
+	/// <summary>
+    ///     The name that is used in searches. If blank, will default to the actual name
+    /// </summary>
+    [DataField("fuzzyName")]
+    public string FuzzyName = string.Empty;
 
     /// <summary>
     ///     "Useful" description displayed in the construction GUI.

--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -1,5 +1,6 @@
 - type: construction
   name: clown vacsuit
+  fuzzyName: vacsuit clown eva hardsuit
   id: ClownHardsuit
   graph: ClownHardsuit
   startNode: start
@@ -11,6 +12,7 @@
 
 - type: construction
   name: mime vacsuit
+  fuzzyName: vacsuit mime eva hardsuit
   id: MimeHardsuit
   graph: MimeHardsuit
   startNode: start
@@ -77,6 +79,7 @@
 
 - type: construction
   name: medsec hud
+  fuzzyName: medical security medsec hud glasses
   id: ClothingEyesHudMedSec
   graph: HudMedSec
   startNode: start

--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -18,6 +18,7 @@
 
 - type: construction
   name: stool
+  fuzzyName: chair stool
   id: Stool
   graph: Seat
   startNode: start
@@ -35,6 +36,7 @@
 
 - type: construction
   name: bar stool
+  fuzzyName: chair stool bar
   id: StoolBar
   graph: Seat
   startNode: start
@@ -376,6 +378,7 @@
 
 - type: construction
   name: wood table
+  fuzzyName: wooden table
   id: TableWood
   graph: Table
   startNode: start
@@ -580,6 +583,7 @@
 
 - type: construction
   name: wood counter
+  fuzzyName: wooden counter
   id: TableCounterWood
   graph: Table
   startNode: start
@@ -616,6 +620,7 @@
 
 - type: construction
   name: toilet
+  fuzzyName: chair toilet
   id: ToiletEmpty
   graph: Toilet
   startNode: start
@@ -652,6 +657,7 @@
 - type: construction
   id: MedicalBed
   name: medical bed
+  fuzzyName: medbay medical bed
   description: A hospital bed for patients to recover in. Resting here provides fairly slow healing.
   graph: bed
   startNode: start
@@ -669,6 +675,7 @@
 - type: construction
   id: DogBed
   name: dog bed
+  fuzzyName: dog pet bed
   description: A comfy-looking dog bed. You can even strap your pet in, in case the gravity turns off.
   graph: bed
   startNode: start
@@ -686,6 +693,7 @@
 - type: construction
   id: Dresser
   name: dresser
+  fuzzyName: wooden dresser
   description: Wooden dresser, can store things inside itself.
   graph: Dresser
   startNode: start
@@ -889,6 +897,7 @@
 - type: construction
   id: Bookshelf
   name: bookshelf
+  fuzzyName: books shelf library
   description: Mostly filled with books.
   graph: Bookshelf
   startNode: start

--- a/Resources/Prototypes/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Recipes/Construction/machines.yml
@@ -1,5 +1,6 @@
 ﻿- type: construction
   name: computer
+  fuzzyName: computer frame
   id: Computer
   graph: Computer
   startNode: start
@@ -81,6 +82,7 @@
 
 - type: construction
   name: signal button
+  fuzzyName: signals button
   id: SignalButtonRecipe
   graph: SignalButtonGraph
   startNode: start
@@ -117,6 +119,7 @@
 
 - type: construction
   name: directional signal switch
+  fuzzyName: signals switch directional
   id: SignalSwitchDirectionalRecipe
   graph: SignalSwitchDirectionalGraph
   startNode: start
@@ -135,6 +138,7 @@
 
 - type: construction
   name: directional signal button
+  fuzzyName: signals button directional
   id: SignalButtonDirectionalRecipe
   graph: SignalButtonDirectionalGraph
   startNode: start

--- a/Resources/Prototypes/Recipes/Construction/storage.yml
+++ b/Resources/Prototypes/Recipes/Construction/storage.yml
@@ -19,6 +19,7 @@
 - type: construction
   id: TallCabinet
   name: tall cabinet
+  fuzzyName: filing cabinet tall
   description: A cabinet for all your filing needs.
   graph: FilingCabinet
   startNode: start
@@ -171,6 +172,7 @@
 - type: construction
   id: ShelfBar
   name: bar shelf
+  fuzzyName: bartender shelf
   description: A convenient place for all your extra booze, specifically designed to hold more bottles!
   graph: Shelf
   startNode: start
@@ -187,6 +189,7 @@
 - type: construction
   id: ShelfKitchen
   name: cooking shelf
+  fuzzyName: kitchen shelf cooking cheef
   description: Holds your knifes, spice, and everything nice!
   graph: Shelf
   startNode: start
@@ -203,6 +206,7 @@
 - type: construction
   id: ShelfChemistry
   name: chemical shelf
+  fuzzyName: chemist shelf chemistry chemical
   description: Perfect for keeping the most important chemicals safe, and out of the clumsy clowns hands!
   graph: Shelf
   startNode: start

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -1,5 +1,6 @@
 - type: construction
   name: girder
+  fuzzyName: metal girder
   id: Girder
   graph: Girder
   startNode: start
@@ -54,6 +55,7 @@
 
 - type: construction
   name: wall
+  fuzzyName: metal wall
   id: Wall
   graph: Girder
   startNode: start
@@ -252,6 +254,7 @@
 
 - type: construction
   name: grille
+  fuzzyName: grille rods
   id: Grille
   graph: Grille
   startNode: start
@@ -288,6 +291,7 @@
 
 - type: construction
   name: diagonal grille
+  fuzzyName: grille diagonal rods
   id: GrilleDiagonal
   graph: GrilleDiagonal
   startNode: start
@@ -322,6 +326,7 @@
 
 - type: construction
   name: window
+  fuzzyName: window glass
   id: Window
   graph: Window
   startNode: start
@@ -341,6 +346,7 @@
 
 - type: construction
   name: diagonal window
+  fuzzyName: window glass diagonal
   id: WindowDiagonal
   graph: WindowDiagonal
   startNode: start
@@ -359,6 +365,7 @@
 
 - type: construction
   name: reinforced window
+  fuzzyName: window glass reinforced
   id: ReinforcedWindow
   graph: Window
   startNode: start
@@ -378,6 +385,7 @@
 
 - type: construction
   name: diagonal reinforced window
+  fuzzyName: window glass reinforced diagonal
   id: ReinforcedWindowDiagonal
   graph: WindowDiagonal
   startNode: start
@@ -396,6 +404,7 @@
 
 - type: construction
   name: tinted window
+  fuzzyName: window glass tinted
   id: TintedWindow
   graph: Window
   startNode: start
@@ -452,6 +461,7 @@
 
 - type: construction
   name: plasma window
+  fuzzyName: window glass plasma
   id: PlasmaWindow
   graph: Window
   startNode: start
@@ -471,6 +481,7 @@
 
 - type: construction
   name: reinforced plasma window
+  fuzzyName: window glass plasma reinforced
   id: ReinforcedPlasmaWindow
   graph: Window
   startNode: start
@@ -490,6 +501,7 @@
 
 - type: construction
   name: diagonal plasma window
+  fuzzyName: window glass plasma diagonal
   id: PlasmaWindowDiagonal
   graph: WindowDiagonal
   startNode: start
@@ -508,6 +520,7 @@
 
 - type: construction
   name: diagonal reinforced plasma window
+  fuzzyName: window glass plasma diagonal reinforced
   id: ReinforcedPlasmaWindowDiagonal
   graph: WindowDiagonal
   startNode: start
@@ -526,6 +539,7 @@
 
 - type: construction
   name: directional window
+  fuzzyName: window glass directional
   id: WindowDirectional
   graph: WindowDirectional
   startNode: start
@@ -544,6 +558,7 @@
 
 - type: construction
   name: directional reinforced window
+  fuzzyName: window glass directional reinforced
   id: WindowReinforcedDirectional
   graph: WindowDirectional
   startNode: start
@@ -580,6 +595,7 @@
 
 - type: construction
   name: directional plasma window
+  fuzzyName: window glass directional plasma
   id: PlasmaWindowDirectional
   graph: WindowDirectional
   startNode: start
@@ -598,6 +614,7 @@
 
 - type: construction
   name: directional reinforced plasma window
+  fuzzyName: window glass directional plasma reinforced
   id: PlasmaReinforcedWindowDirectional
   graph: WindowDirectional
   startNode: start
@@ -616,6 +633,7 @@
 
 - type: construction
   name: uranium window
+  fuzzyName: window glass uranium
   id: UraniumWindow
   graph: Window
   startNode: start
@@ -635,6 +653,7 @@
 
 - type: construction
   name: reinforced uranium window
+  fuzzyName: window glass uranium reinforced
   id: ReinforcedUraniumWindow
   graph: Window
   startNode: start
@@ -654,6 +673,7 @@
 
 - type: construction
   name: diagonal uranium window
+  fuzzyName: window glass uranium diagonal
   id: UraniumWindowDiagonal
   graph: WindowDiagonal
   startNode: start
@@ -672,6 +692,7 @@
 
 - type: construction
   name: diagonal reinforced uranium window
+  fuzzyName: window glass diagonal reinforced uranium
   id: ReinforcedUraniumWindowDiagonal
   graph: WindowDiagonal
   startNode: start
@@ -690,6 +711,7 @@
 
 - type: construction
   name: directional uranium window
+  fuzzyName: window glass directional uranium
   id: UraniumWindowDirectional
   graph: WindowDirectional
   startNode: start
@@ -708,6 +730,7 @@
 
 - type: construction
   name: directional reinforced uranium window
+  fuzzyName: window glass directional uranium reinforced
   id: UraniumReinforcedWindowDirectional
   graph: WindowDirectional
   startNode: start
@@ -726,6 +749,7 @@
 
 - type: construction
   name: firelock
+  fuzzyName: door firelock atmos
   id: Firelock
   graph: Firelock
   startNode: start
@@ -743,6 +767,7 @@
 
 - type: construction
   name: glass firelock
+  fuzzyName: door firelock atmos glass window
   id: FirelockGlass
   graph: Firelock
   startNode: start
@@ -760,6 +785,7 @@
 
 - type: construction
   name: Thin firelock
+  fuzzyName: door firelock atmos thin
   id: FirelockEdge
   graph: Firelock
   startNode: start
@@ -1224,6 +1250,7 @@
 #Airlocks
 - type: construction
   name: airlock
+  fuzzyName: airlock door
   id: Airlock
   graph: Airlock
   startNode: start
@@ -1241,6 +1268,7 @@
 
 - type: construction
   name: glass airlock
+  fuzzyName: airlock door glass
   id: AirlockGlass
   graph: Airlock
   startNode: start
@@ -1258,6 +1286,7 @@
 
 - type: construction
   name: pinion airlock
+  fuzzyName: airlock door pinion
   id: PinionAirlock
   graph: PinionAirlock
   startNode: start
@@ -1275,6 +1304,7 @@
 
 - type: construction
   name: glass pinion airlock
+  fuzzyName: airlock door pinion glass
   id: PinionAirlockGlass
   graph: PinionAirlock
   startNode: start
@@ -1292,6 +1322,7 @@
 
 - type: construction
   name: shuttle airlock
+  fuzzyName: airlock door shuttle
   id: AirlockShuttle
   graph: AirlockShuttle
   startNode: start
@@ -1310,6 +1341,7 @@
 
 - type: construction
   name: glass shuttle airlock
+  fuzzyName: airlock door shuttle glass
   id: AirlockGlassShuttle
   graph: AirlockShuttle
   startNode: start
@@ -1328,6 +1360,7 @@
 
 - type: construction
   name: windoor
+  fuzzyName: door window windoor glass
   id: Windoor
   graph: Windoor
   startNode: start
@@ -1345,6 +1378,7 @@
 
 - type: construction
   name: secure windoor
+  fuzzyName: door window windoor glass secure locked
   id: SecureWindoor
   graph: Windoor
   startNode: start
@@ -1362,6 +1396,7 @@
 
 - type: construction
   name: clockwork windoor
+  fuzzyName: door window windoor clockwork
   id: ClockworkWindoor
   graph: Windoor
   startNode: start
@@ -1659,6 +1694,7 @@
 
 - type: construction
   name: solid secret door
+  fuzzyName: solid secret door fake wall
   id: SolidSecretDoor
   graph: SecretDoor
   startNode: start

--- a/Resources/Prototypes/Recipes/Construction/tools.yml
+++ b/Resources/Prototypes/Recipes/Construction/tools.yml
@@ -11,6 +11,7 @@
 
 - type: construction
   name: logic gate
+  fuzzyName: signals logic gate
   id: LogicGate
   graph: LogicGate
   startNode: start
@@ -22,6 +23,7 @@
 
 - type: construction
   name: edge detector
+  fuzzyName: signals edge detector
   id: EdgeDetector
   graph: LogicGate
   startNode: start
@@ -33,6 +35,7 @@
 
 - type: construction
   name: power sensor
+  fuzzyName: signals power sensor
   id: PowerSensor
   graph: LogicGate
   startNode: start

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -762,7 +762,7 @@
 
 - type: construction
   id: GasFilterFlipped
-  hide: true
+  hide: false
   name: gas filter (flipped)
   fuzzyName: pipe gas atmos air filter
   description: Very useful for filtering gases.
@@ -799,7 +799,7 @@
 
 - type: construction
   id: GasMixerFlipped
-  hide: true
+  hide: false
   name: gas mixer (flipped)
   fuzzyName: pipe gas atmos air mixer
   description: Very useful for mixing gases.

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -1,6 +1,7 @@
 # SURVEILLANCE
 - type: construction
   name: camera
+  fuzzyName: cameras surveillance
   id: camera
   graph: SurveillanceCamera
   startNode: start
@@ -15,6 +16,7 @@
 
 - type: construction
   name: telescreen
+  fuzzyName: telescreen cameras monitor surveillance
   id: WallmountTelescreen
   graph: WallmountTelescreen
   startNode: start
@@ -49,6 +51,7 @@
 # POWER
 - type: construction
   name: APC
+  fuzzyName: APC Area Power Controller
   id: APC
   graph: APC
   startNode: start
@@ -64,6 +67,7 @@
 
 - type: construction
   name: solar assembly
+  fuzzyName: solars assembly power
   id: SolarPanel
   graph: SolarPanel
   startNode: start
@@ -82,6 +86,7 @@
 
 - type: construction
   name: cable terminal
+  fuzzyName: cable terminal power
   id: CableTerminal
   graph: CableTerminal
   startNode: start
@@ -97,6 +102,7 @@
 
 - type: construction
   name: wallmount substation
+  fuzzyName: wallmounted substation power
   id: WallmountSubstation
   graph: WallmountSubstation
   startNode: start
@@ -112,6 +118,7 @@
 
 - type: construction
   name: wallmount generator
+  fuzzyName: wallmounted generator power
   id: WallmountGenerator
   graph: WallmountGenerator
   startNode: start
@@ -127,6 +134,7 @@
 
 - type: construction
   name: wallmount APU
+  fuzzyName: wallmounted APU power
   id: WallmountGeneratorAPU
   graph: WallmountGenerator
   startNode: start
@@ -143,6 +151,7 @@
 # DISPOSALS
 - type: construction
   name: disposal unit
+  fuzzyName: disposals unit
   description: A pneumatic waste disposal unit.
   id: DisposalUnit
   graph: DisposalMachine
@@ -157,6 +166,7 @@
 
 - type: construction
   name: mailing unit
+  fuzzyName: mailing unit disposals
   description: A pneumatic mail delivery unit.
   id: MailingUnit
   graph: DisposalMachine
@@ -171,6 +181,7 @@
 
 - type: construction
   name: disposal pipe
+  fuzzyName: disposals pipe
   id: DisposalPipe
   description: A huge pipe segment used for constructing disposal systems.
   graph: DisposalPipe
@@ -185,6 +196,7 @@
 
 - type: construction
   name: disposal tagger
+  fuzzyName: disposals tagger
   description: A pipe that tags entities for routing.
   id: DisposalTagger
   graph: DisposalPipe
@@ -199,6 +211,7 @@
 
 - type: construction
   name: disposal trunk
+  fuzzyName: disposals trunk
   description: A pipe trunk used as an entry point for disposal systems.
   id: DisposalTrunk
   graph: DisposalPipe
@@ -213,6 +226,7 @@
 
 - type: construction
   name: disposal router
+  fuzzyName: disposals router
   description: A three-way router. Entities with matching tags get routed to the side.
   id: DisposalRouter
   graph: DisposalPipe
@@ -227,8 +241,9 @@
   mirror: DisposalRouterFlipped
 
 - type: construction
-  hide: true
-  name: disposal router
+  hide: false
+  name: disposal router (flipped)
+  fuzzyName: disposals router
   description: A three-way router. Entities with matching tags get routed to the side.
   id: DisposalRouterFlipped
   graph: DisposalPipe
@@ -244,6 +259,7 @@
 
 - type: construction
   name: disposal signal router
+  fuzzyName: disposals signal router
   description: A signal-controlled three-way router.
   id: DisposalSignalRouter
   graph: DisposalPipe
@@ -258,8 +274,9 @@
   mirror: DisposalSignalRouterFlipped
 
 - type: construction
-  hide: true
-  name: disposal signal router
+  hide: false
+  name: disposal signal router (flipped)
+  fuzzyName: disposals signal router
   description: A signal-controlled three-way router.
   id: DisposalSignalRouterFlipped
   graph: DisposalPipe
@@ -275,6 +292,7 @@
 
 - type: construction
   name: disposal junction
+  fuzzyName: disposals junction three way
   description: A three-way junction. The arrow indicates where items exit.
   id: DisposalJunction
   graph: DisposalPipe
@@ -289,8 +307,9 @@
   mirror: DisposalJunctionFlipped
 
 - type: construction
-  hide: true
-  name: disposal junction
+  hide: false
+  name: disposal junction (flipped)
+  fuzzyName: disposals junction three way
   description: A three-way junction. The arrow indicates where items exit.
   id: DisposalJunctionFlipped
   graph: DisposalPipe
@@ -306,6 +325,7 @@
 
 - type: construction
   name: disposal Y junction
+  fuzzyName: disposals Y junction three way
   description: A three-way junction with another exit point.
   id: DisposalYJunction
   graph: DisposalPipe
@@ -320,6 +340,7 @@
 
 - type: construction
   name: disposal bend
+  fuzzyName: disposals bend
   description: A tube bent at a 90 degree angle.
   id: DisposalBend
   graph: DisposalPipe
@@ -335,6 +356,7 @@
 # ATMOS
 - type: construction
   name: air alarm
+  fuzzyName: air alarm atmos
   id: AirAlarmFixture
   graph: AirAlarm
   startNode: start
@@ -353,6 +375,7 @@
 
 - type: construction
   name: fire alarm
+  fuzzyName: fire alarm atmos
   id: FireAlarm
   graph: FireAlarm
   startNode: start
@@ -371,6 +394,7 @@
 
 - type: construction
   name: air sensor
+  fuzzyName: pipe gas atmos air sensor
   id: AirSensor
   graph: AirSensor
   startNode: start
@@ -387,6 +411,7 @@
 # ATMOS PIPES
 - type: construction
   name: gas pipe half
+  fuzzyName: pipe gas atmos air half
   id: GasPipeHalf
   description: Half of a gas pipe. No skateboards.
   graph: GasPipe
@@ -401,6 +426,7 @@
 
 - type: construction
   name: gas pipe straight
+  fuzzyName: pipe gas atmos air straight
   id: GasPipeStraight
   description: A straight pipe segment.
   graph: GasPipe
@@ -415,6 +441,7 @@
 
 - type: construction
   name: gas pipe bend
+  fuzzyName: pipe gas atmos air bend
   id: GasPipeBend
   description: A pipe segment bent at a 90 degree angle.
   graph: GasPipe
@@ -429,6 +456,7 @@
 
 - type: construction
   name: gas pipe T junction
+  fuzzyName: pipe gas atmos air t junction three way
   id: GasPipeTJunction
   description: A pipe segment with a T junction.
   graph: GasPipe
@@ -443,6 +471,7 @@
 
 - type: construction
   name: gas pipe fourway
+  fuzzyName: pipe gas atmos air fourway
   id: GasPipeFourway
   description: A pipe segment with a fourway junction.
   graph: GasPipe
@@ -458,6 +487,7 @@
 # ATMOS UNARY
 - type: construction
   name: air vent
+  fuzzyName: pipe gas atmos air vent unary pump
   description: Pumps gas into the room.
   id: GasVentPump
   graph: GasUnary
@@ -479,6 +509,7 @@
 
 - type: construction
   name: passive vent
+  fuzzyName: pipe gas atmos air vent passive
   description: Unpowered vent that equalises gases on both sides.
   id: GasPassiveVent
   graph: GasUnary
@@ -500,6 +531,7 @@
 
 - type: construction
   name: air scrubber
+  fuzzyName: pipe gas atmos air scrubber
   description: Sucks gas into connected pipes.
   id: GasVentScrubber
   graph: GasUnary
@@ -521,6 +553,7 @@
 
 - type: construction
   name: air injector
+  fuzzyName: pipe gas atmos air injector
   description: Injects air into the atmosphere.
   id: GasOutletInjector
   graph: GasUnary
@@ -543,6 +576,7 @@
 # ATMOS BINARY
 - type: construction
   name: gas pump
+  fuzzyName: pipe gas atmos air pump pressure
   id: GasPressurePump
   description: A pump that moves gas by pressure.
   graph: GasBinary
@@ -564,6 +598,7 @@
 
 - type: construction
   name: volumetric gas pump
+  fuzzyName: pipe gas atmos air pump volume
   description: A pump that moves gas by volume.
   id: GasVolumePump
   graph: GasBinary
@@ -586,6 +621,7 @@
 - type: construction
   id: GasPassiveGate
   name: passive gate
+  fuzzyName: pipe gas atmos air passive gate one way
   description: A one-way air valve that does not require power.
   graph: GasBinary
   startNode: start
@@ -607,6 +643,7 @@
 - type: construction
   id: GasValve
   name: manual valve
+  fuzzyName: pipe gas atmos air valve manual
   description: A pipe with a valve that can be used to disable the flow of gas through it.
   graph: GasBinary
   startNode: start
@@ -628,6 +665,7 @@
 - type: construction
   id: SignalControlledValve
   name: signal valve
+  fuzzyName: pipe gas atmos air valve digital signal
   description: Valve controlled by signal inputs.
   graph: GasBinary
   startNode: start
@@ -649,6 +687,7 @@
 - type: construction
   id: GasPort
   name: connector port
+  fuzzyName: pipe gas atmos air canister connector port
   description: For connecting portable devices related to atmospherics control.
   graph: GasBinary
   startNode: start
@@ -670,6 +709,7 @@
 - type: construction
   id: GasDualPortVentPump
   name: dual-port air vent
+  fuzzyName: pipe gas atmos air vent pump dual port
   description: Has a valve and a pump attached to it. There are two ports, one is an input for releasing air, the other is an output when siphoning.
   graph: GasBinary
   startNode: start
@@ -689,6 +729,7 @@
 - type: construction
   id: HeatExchanger
   name: radiator
+  fuzzyName: pipe gas atmos air radiator heat exchanger HE
   description: Transfers heat between the pipe and its surroundings.
   graph: GasBinary
   startNode: start
@@ -704,6 +745,7 @@
 - type: construction
   id: GasFilter
   name: gas filter
+  fuzzyName: pipe gas atmos air filter
   description: Very useful for filtering gases.
   graph: GasTrinary
   startNode: start
@@ -721,7 +763,8 @@
 - type: construction
   id: GasFilterFlipped
   hide: true
-  name: gas filter
+  name: gas filter (flipped)
+  fuzzyName: pipe gas atmos air filter
   description: Very useful for filtering gases.
   graph: GasTrinary
   startNode: start
@@ -739,6 +782,7 @@
 - type: construction
   id: GasMixer
   name: gas mixer
+  fuzzyName: pipe gas atmos air mixer
   description: Very useful for mixing gases.
   graph: GasTrinary
   startNode: start
@@ -756,7 +800,8 @@
 - type: construction
   id: GasMixerFlipped
   hide: true
-  name: gas mixer
+  name: gas mixer (flipped)
+  fuzzyName: pipe gas atmos air mixer
   description: Very useful for mixing gases.
   graph: GasTrinary
   startNode: start
@@ -774,6 +819,7 @@
 - type: construction
   id: PressureControlledValve
   name: pneumatic valve
+  fuzzyName: pipe gas atmos air valve pneumatic pressure
   description: Valve controlled by pressure.
   graph: GasTrinary
   startNode: start
@@ -790,6 +836,7 @@
 # INTERCOM
 - type: construction
   name: intercom
+  fuzzyName: intercom radio
   id: IntercomAssembly
   graph: Intercom
   startNode: start
@@ -809,6 +856,7 @@
 # TIMERS
 - type: construction
   name: signal timer
+  fuzzyName: signals timer
   id: SignalTimer
   graph: Timer
   startNode: start
@@ -826,6 +874,7 @@
 
 - type: construction
   name: screen timer
+  fuzzyName: signals timer screen
   id: ScreenTimer
   graph: Timer
   startNode: start
@@ -844,6 +893,7 @@
 
 - type: construction
   name: brig timer
+  fuzzyName: signals timer brig
   id: BrigTimer
   graph: Timer
   startNode: start

--- a/Resources/Prototypes/Recipes/Construction/weapons.yml
+++ b/Resources/Prototypes/Recipes/Construction/weapons.yml
@@ -33,6 +33,7 @@
 
 - type: construction
   name: reinforced shiv
+  fuzzyName: reinforced glass shiv
   id: ReinforcedShiv
   graph: ReinforcedShiv
   startNode: start
@@ -44,6 +45,7 @@
 
 - type: construction
   name: plasma shiv
+  fuzzyName: plasma glass shiv
   id: PlasmaShiv
   graph: PlasmaShiv
   startNode: start
@@ -55,6 +57,7 @@
 
 - type: construction
   name: uranium shiv
+  fuzzyName: uranium glass shiv
   id: UraniumShiv
   graph: UraniumShiv
   startNode: start
@@ -110,6 +113,7 @@
 
 - type: construction
   name: makeshift bola
+  fuzzyName: makeshift bolas
   id: Bola
   graph: Bola
   startNode: start

--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -81,6 +81,7 @@
 
 - type: construction
   name: web crate
+  fuzzyName: web crate storage
   id: CrateWeb
   graph: WebStructures
   startNode: start


### PR DESCRIPTION
## what this does
makes the crafting menu use a fuzzy search for its results
UNATOMICALLY unhides some hidden flipped variants of disposal piping and pipe devices because show me them REEEEEEE

## why it's good
easier to find things you want, allows you to be a bit more particular and fast with lookups

## how it was tested
went in game and entered a few searches to ensured they worked correctly

Changelog
:cl:
    add: Added a fuzzy search to the crafting menu
    tweak: unhid some recipies
