### PR TITLE
Tile Movement AI Support, adds Tile Movement by default to all mobs

### DIFF
--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -170,7 +170,8 @@ public sealed partial class NPCCombatSystem
             var goalRotation = (targetSpot - worldPos).ToWorldAngle();
             var rotationSpeed = comp.RotationSpeed;
 
-            if (!_rotate.TryRotateTo(uid, goalRotation, frameTime, comp.AccuracyThreshold, rotationSpeed?.Theta ?? double.MaxValue, xform))
+            if (Double.IsNaN(goalRotation.Theta) ||
+                !_rotate.TryRotateTo(uid, goalRotation, frameTime, comp.AccuracyThreshold, rotationSpeed?.Theta ?? double.MaxValue, xform))
             {
                 continue;
             }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -597,6 +597,9 @@ namespace Content.Shared.Movement.Systems
         /// pixel movement and the rigidity of tiles. Works surprisingly well.
         /// Note: the code is intentionally separated here from everything else to make it easier to port and
         /// to reduce the risk of merge conflicts.
+        /// However, I would also NOT recommend porting it right now unless you're okay with continually updating it.
+        /// For one, a shapecast-based implementation rather than a true physics implementation is in the cards for
+        /// the future. For another, it's not terribly clean and is not integrated too well into existing movement code.
 
         /// <summary>
         /// Runs one tick of tile-based movement on the given inputs.
@@ -608,7 +611,7 @@ namespace Content.Shared.Movement.Systems
         /// <param name="targetTransform">TransformComponent on the entity doing the move.</param>
         /// <param name="inputMover">InputMoverComponent on the entity doing the move.</param>
         /// <param name="tileDef">ContentTileDefinition of the tile underneath the entity doing the move, if there is one.</param>
-        /// <param name="relayTarget"></param>
+        /// <param name="relayTarget">MovementRelayTargetComponent on the relay target, if any.</param>
         /// <param name="frameTime">Time in seconds since the last tick of the physics system.</param>
         /// <returns></returns>
         public bool HandleTileMovement(
@@ -784,7 +787,7 @@ namespace Content.Shared.Movement.Systems
             var stoppedPressing = pressedButtons != tileMovement.CurrentSlideMoveButtons;
             var minDurationPassed = CurrentTime - tileMovement.MovementKeyInitialDownTime >= TimeSpan.FromSeconds(minPressedTime);
             var noProgress = tileMovement.LastTickLocalCoordinates != null && transform.LocalPosition.EqualsApprox(tileMovement.LastTickLocalCoordinates.Value, destinationTolerance/3);
-            var hardDurationLimitPassed = CurrentTime - tileMovement.MovementKeyInitialDownTime >= TimeSpan.FromSecondsa(minPressedTime) * 3;
+            var hardDurationLimitPassed = CurrentTime - tileMovement.MovementKeyInitialDownTime >= TimeSpan.FromSeconds(minPressedTime) * 3;
             return reachedDestination || (stoppedPressing && (minDurationPassed || noProgress)) || hardDurationLimitPassed;
         }
 
@@ -905,16 +908,6 @@ namespace Content.Shared.Movement.Systems
         }
 
         /// <summary>
-        /// Returns the given local coordinates snapped to the center of the tile it is currently on.
-        /// </summary>
-        /// <param name="input">Given coordinates to snap.</param>
-        /// <returns>The closest tile center to the input.<returns>
-        private Vector2 SnapCoordinatesToTile(Vector2 input)
-        {
-            return new Vector2((int) Math.Floor(input.X) + 0.5f, (int) Math.Floor(input.Y) + 0.5f);
-        }
-
-        /// <summary>
         /// Instantly snaps/teleports an entity to the center of the tile it is currently standing on based on the
         /// given grid. Does not trigger collisions on the way there, but does trigger collisions after the snap.
         /// </summary>
@@ -979,6 +972,16 @@ namespace Content.Shared.Movement.Systems
         private MoveButtons StripWalk(MoveButtons input)
         {
             return input & ~MoveButtons.Walk;
+        }
+
+        /// <summary>
+        /// Returns the given local coordinates snapped to the center of the tile it is currently on.
+        /// </summary>
+        /// <param name="input">Given coordinates to snap.</param>
+        /// <returns>The closest tile center to the input.<returns>
+        public static Vector2 SnapCoordinatesToTile(Vector2 input)
+        {
+            return new Vector2((int) Math.Floor(input.X) + 0.5f, (int) Math.Floor(input.Y) + 0.5f);
         }
     }
 }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -750,7 +750,6 @@ namespace Content.Shared.Movement.Systems
                         inputMover.RelativeEntity,
                         out TransformComponent? parentTransform))
                     {
-
                         var delta = tileMovement.Destination - tileMovement.Origin.Position;
                         var worldRot = _transform.GetWorldRotation(parentTransform).RotateVec(delta).ToWorldAngle();
                         _transform.SetWorldRotation(targetTransform, worldRot);

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -24,6 +24,7 @@
   - type: Clickable
   - type: InteractionOutline
   - type: InputMover
+  - type: TileMovement
   - type: Input
     context: "human"
   - type: LagCompensation


### PR DESCRIPTION
As title says. Also adds a hard limit to tile movements as a fallback for bugs and fixes an outstanding bug with AI that breaks the server if a ranged AI shoots a guy standing on the exact same position as it (which never happened with pixel since they never were on the EXACT same position)