### PR TITLE
/vg/chem Part 1

### DIFF
--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -42,7 +42,8 @@ namespace Content.Client.Chemistry.UI
 
             ReagentList.Children.Clear();
             //Sort inventory by reagentLabel
-            inventory.Sort((x, y) => x.ReagentLabel.CompareTo(y.ReagentLabel));
+            //inventory.Sort((x, y) => x.ReagentLabel.CompareTo(y.ReagentLabel));
+            // default order is that of creation, ie. mirror prototype for default entities
 
             foreach (var item in inventory)
             {

--- a/Resources/Locale/en-US/reagents/meta/botany.ftl
+++ b/Resources/Locale/en-US/reagents/meta/botany.ftl
@@ -2,7 +2,7 @@ reagent-name-e-z-nutrient = EZ nutrient
 reagent-desc-e-z-nutrient = Give your plants some of those EZ nutrients! Dionas find this delicious.
 
 reagent-name-left4-zed = left-4-zed
-reagent-desc-left4-zed = A cocktail of mutagenic compounds that gives nutrients, harms and affects plant life's genome.
+reagent-desc-left4-zed = A cocktail of mutagenic compounds which cause plant life to become highly unstable.
 
 reagent-name-pest-killer = pest killer
 reagent-desc-pest-killer = A mixture that targets pests. While useful it slowly poisons plants with toxins, be careful when using it.
@@ -20,7 +20,7 @@ reagent-name-ammonia = ammonia
 reagent-desc-ammonia = An effective fertilizer, it gives your plants some nutrients.
 
 reagent-name-diethylamine = diethylamine
-reagent-desc-diethylamine = A very potent fertilizer, treats plants with nutrients, eliminates pests, and sometimes it can even speed up growth.
+reagent-desc-diethylamine = A secondary amine, mildly corrosive.
 
 reagent-name-sedin = sedin
 reagent-desc-sedin = A modified version of diethylamine that can restore seeds on plants at the cost of potency.

--- a/Resources/Locale/en-US/reagents/meta/elements.ftl
+++ b/Resources/Locale/en-US/reagents/meta/elements.ftl
@@ -37,6 +37,12 @@ reagent-desc-lithium = A soft, silvery-white alkali metal. It's highly reactive,
 reagent-name-mercury = mercury
 reagent-desc-mercury = A silver metal which is liquid at room temperature. It's highly toxic to humans.
 
+reagent-name-nitrogen = nitrogen
+reagent-desc-nitrogen = A colorless, odorless, tasteless gas.
+
+reagent-name-oxygen = oxygen
+reagent-desc-oxygen = A colorless, odorless gas.
+
 reagent-name-potassium = potassium
 reagent-desc-potassium = A soft, shiny grey metal. Even more reactive than lithium.
 
@@ -65,4 +71,4 @@ reagent-name-bananium = bananium
 reagent-desc-bananium = A yellow radioactive organic solid.
 
 reagent-name-zinc = zinc
-reagent-desc-zinc = A silvery, brittle metal, often used in batteries to carry charge. 
+reagent-desc-zinc = A silvery, brittle metal, often used in batteries to carry charge.

--- a/Resources/Locale/en-US/reagents/meta/elements.ftl
+++ b/Resources/Locale/en-US/reagents/meta/elements.ftl
@@ -37,12 +37,6 @@ reagent-desc-lithium = A soft, silvery-white alkali metal. It's highly reactive,
 reagent-name-mercury = mercury
 reagent-desc-mercury = A silver metal which is liquid at room temperature. It's highly toxic to humans.
 
-reagent-name-nitrogen = nitrogen
-reagent-desc-nitrogen = A colorless, odorless, tasteless gas.
-
-reagent-name-oxygen = oxygen
-reagent-desc-oxygen = A colorless, odorless gas.
-
 reagent-name-potassium = potassium
 reagent-desc-potassium = A soft, shiny grey metal. Even more reactive than lithium.
 

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -155,7 +155,7 @@ reagent-name-tramadol = tramadol
 reagent-desc-tramadol = A simple, yet effective, painkiller.
 
 reagent-name-alkysine = alkysine
-reagent-name-alkysine = Alkysine is a drug used to lessen the damage to neurological tissue after a catastrophic injury. Can heal brain tissue.
+reagent-desc-alkysine = Alkysine is a drug used to lessen the damage to neurological tissue after a catastrophic injury. Can heal brain tissue.
 
 reagent-name-alkycosine = alkycosine
 reagent-desc-alkycosine = A mind-stablizing brain bleach.
@@ -205,3 +205,50 @@ reagent-desc-methylin = An intelligence enhancer, also used in the treatment of 
 reagent-name-nanobots = nanobots
 reagent-desc-nanobots = Microscopic robots intended for use in humans. Must be loaded with further chemicals to be useful.
 
+reagent-name-oxycodone = oxycodone
+reagent-desc-oxycodone = An effective and very addictive painkiller.
+
+reagent-name-paracetamol = paracetamol
+reagent-desc-paracetamol = Most commonly know this as Tylenol, but this chemical is a mild, simple painkiller.
+
+reagent-name-paroxetine = paroxetine
+reagent-desc-paroxetine = Stabilizes the mind greatly, but has a chance of adverse effects.
+
+reagent-name-peptobismol = peptobismol
+reagent-desc-peptobismol = Jesus juice.
+
+reagent-name-peridaxon = peridaxon
+reagent-desc-peridaxon = Used to encourage recovery of internal organs and nervous systems. Medicate cautiously.
+
+reagent-name-piccolyn = piccolyn
+reagent-desc-piccolyn = Prescribed daily.
+
+reagent-name-preslomite = preslomite
+reagent-desc-preslomite = A stabilizing chemical used in industrial relief efforts.
+
+reagent-name-priaxate = priaxate
+reagent-desc-priaxate = Priaxate is a broad spectrum medication formulated for the unique biology of vox. While still effective on other species, some of its effects are less potent.
+
+reagent-name-rezadone = rezadone
+reagent-desc-rezadone = A powder derived from fish toxin, this substance can effectively treat genetic damage in humanoids, though excessive consumption has side effects.
+
+reagent-name-ryetalyn = ryetalyn
+reagent-desc-ryetalyn = Ryetalyn can cure all genetic abnomalities.
+
+reagent-name-simpolinol = simpolinol
+reagent-desc-simpolinol = An experimental medication which has shown promising results in animal tests. Has not yet advanced to human trials.
+
+reagent-name-soporificrejuvenant = soporific rejuvenant
+reagent-desc-soporificrejuvenant = Puts people to sleep while healing them.
+
+reagent-name-stabilizine = stabilizine
+reagent-desc-stabilizine = A stabilizing chemical produced by alien nests to keep their occupants barely alive.
+
+reagent-name-sterilizine = sterilizine
+reagent-desc-sterilizine = Sterilizes wounds in preparation for surgery.
+
+reagent-name-synthocarisol = synthocarisol
+reagent-desc-synthocarisol = Synthocarisol is a synthetic version of Carisol, a powerful analgesic that used to be found in traditional medicines made from the horn of the now-extinct Space African Rhino. Tragically, the horns also contained an equal amount of Anticarisol, which led to the medical community dismissing the remedies as nothing more than placebo and overlooking this reagent for several centuries.
+
+reagent-name-trinitrine = trinitrine
+reagent-desc-trinitrine = Glyceryl Trinitrate, also known as diluted nitroglycerin, is a medication used for heart failure and to treat and prevent chest pain due to hyperzine.

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -20,28 +20,28 @@ reagent-name-doxarubixadone = doxarubixadone
 reagent-desc-doxarubixadone = A cryogenics chemical. Heals certain types of cellular damage done by Slimes and improper use of other chemicals.
 
 reagent-name-dermaline = dermaline
-reagent-desc-dermaline = An advanced chemical that is more effective at treating burn damage than kelotane.
+reagent-desc-dermaline = Dermaline is the next step in burn medication. Works twice as good as kelotane and enables the body to restore even the direst heat-damaged tissue."
 
 reagent-name-dexalin = dexalin
-reagent-desc-dexalin = Used for treating minor oxygen deprivation and bloodloss. A required reagent for dexalin plus.
+reagent-desc-dexalin = Dexalin is used in the treatment of oxygen deprivation.
 
 reagent-name-dexalin-plus = dexalin plus
-reagent-desc-dexalin-plus = Used in treatment of extreme cases of oxygen deprivation and bloodloss. Flushes heartbreaker toxin out of the blood stream.
+reagent-desc-dexalin-plus = Dexalin Plus is used in the treatment of oxygen deprivation. Its highly effective.
 
 reagent-name-epinephrine = epinephrine
 reagent-desc-epinephrine = An effective stabilizing chemical used to keep a critical person from dying to asphyxiation while patching up minor damage during crit. Flushes heartbreaker toxin out the blood stream at the cost of more epinephrine, but may add histamine. Helps reduce stun time. Commonly found in the form of emergency medipens.
 
 reagent-name-hyronalin = hyronalin
-reagent-desc-hyronalin = A weak treatment for radiation damage. A precursor to arithrazine and phalanximine. Can cause vomiting.
+reagent-desc-hyronalin = Hyronalin is a medicinal drug used to counter the effect of radiation poisoning.
 
 reagent-name-ipecac = ipecac
 reagent-desc-ipecac = A rapid-acting emetic. Useful for stopping unmetabolized poisons, or mass-vomiting sessions.
 
 reagent-name-inaprovaline = inaprovaline
-reagent-desc-inaprovaline = Inaprovaline is a synaptic stimulant and cardiostimulant, commonly used to treat asphyxiation damage caused during critical states and reduce bleeding. Used in many advanced medicines.
+reagent-desc-inaprovaline = Inaprovaline is a synaptic stimulant and cardiostimulant. Commonly used to stabilize patients.
 
 reagent-name-kelotane = kelotane
-reagent-desc-kelotane = Treats burn damage. Overdosing greatly reduces the body's ability to retain water.
+reagent-desc-kelotane = Kelotane is a drug used to treat burns.
 
 reagent-name-leporazine = leporazine
 reagent-desc-leporazine = A chemical used to stabilize body temperature and rapidly cure cold damage. Great for unprotected EVA travel, but prevents the use of cryogenic tubes.
@@ -92,7 +92,7 @@ reagent-name-oculine = oculine
 reagent-desc-oculine = A simple saline compound used to treat the eyes via ingestion.
 
 reagent-name-ethylredoxrazine = ethylredoxrazine
-reagent-desc-ethylredoxrazine = Neutralises the effects of alcohol in the blood stream. Though it is commonly needed, it is rarely requested.
+reagent-desc-ethylredoxrazine = A powerful oxidizer that reacts with ethanol.
 
 reagent-name-cognizine = cognizine
 reagent-desc-cognizine = A mysterious chemical which is able to make any non-sentient creature sentient.
@@ -147,3 +147,61 @@ reagent-desc-potassium-iodide = Will reduce the damaging effects of radiation by
 
 reagent-name-haloperidol = haloperidol
 reagent-desc-haloperidol = Removes most stimulating and hallucinogenic drugs. Reduces druggy effects and jitteriness. Causes drowsiness.
+
+reagent-name-albuterol = albuterol
+reagent-desc-albuterol = A bronchodilator that relaxes muscles in the airways and increases air flow to the lungs.
+
+reagent-name-tramadol = tramadol
+reagent-desc-tramadol = A simple, yet effective, painkiller.
+
+reagent-name-alkysine = alkysine
+reagent-name-alkysine = Alkysine is a drug used to lessen the damage to neurological tissue after a catastrophic injury. Can heal brain tissue.
+
+reagent-name-alkycosine = alkycosine
+reagent-desc-alkycosine = A mind-stablizing brain bleach.
+
+reagent-name-spaceacillin = spaceacillin
+reagent-desc-spaceacillin = A generic antipathogenic agent.
+
+reagent-name-nanofloxacin = nanofloxacin
+reagent-desc-nanofloxacin = An extremely powerful antipathogenic. To take in equally extremely small doses, or face a variety of adverse effects.
+
+reagent-name-biofoam = biofoam
+reagent-desc-biofoam = A fast-hardening, biocompatible foam used to stem internal bleeding for a short time.
+
+reagent-name-citalopram = citalopram
+reagent-desc-citalopram = Stabilizes the mind a little.
+
+reagent-name-clonexadone = clonexadone
+reagent-desc-clonexadone = A liquid compound similar to that used in the cloning process. Can be used to 'finish' the cloning process when used in conjunction with a cryo tube.
+
+reagent-name-clottingagent = clotting agent
+reagent-desc-clottingagent = Concentrated blood platelets. Capable of stemming bleeding.
+
+reagent-name-combatnanobots = combat nanobots
+reagent-desc-combatnanobots = Microscopic robots intended for use in humans. Configured to grant great resistance to damage.
+
+reagent-name-degeneratecalcium = degenerate calcium
+reagent-desc-degeneratecalcium = A highly radical chemical derived from calcium that aggressively attempts to regenerate osseous tissues it comes in contact with. In the presence of micro-fractures caused by extensive brute damage it rapidly heals the surrounding tissues, but in healthy limbs the new tissue quickly causes the bone structure to lose shape and shatter rather graphically.
+
+reagent-name-dietine = dietine
+reagent-desc-dietine = An uncommon makeshift weight loss aid. Mildly toxic, moreso in larger doses.
+
+reagent-name-imidazoline = imidazoline
+reagent-desc-imidazoline = Heals eye damage.
+
+reagent-name-inacusiate = inacusiate
+reagent-desc-inacusiate = Rapidly heals ear damage.
+
+reagent-name-lithotorcrazine = lithotorcrazine
+reagent-desc-lithotorcrazine = A derivative of Arithrazine. Rather than reducing radiation in a host, actively impedes the host from being irradiated instead.
+
+reagent-name-medicalnanobots = medical nanobots
+reagent-desc-medicalnanobots = Microscopic robots intended for use in humans. Configured for rapid healing upon infiltration into the body.
+
+reagent-name-methylin = methylin
+reagent-desc-methylin = An intelligence enhancer, also used in the treatment of attention deficit hyperactivity disorder. Also known as Ritalin.
+
+reagent-name-nanobots = nanobots
+reagent-desc-nanobots = Microscopic robots intended for use in humans. Must be loaded with further chemicals to be useful.
+

--- a/Resources/Locale/en-US/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/reagents/meta/narcotics.ftl
@@ -40,5 +40,5 @@ reagent-desc-tear-gas = A chemical that causes severe irritation and crying, com
 reagent-name-happiness = happiness
 reagent-desc-happiness = Fills you with ecstatic numbness and causes minor brain damage. Highly addictive. If overdosed causes sudden mood swings.
 
-reagent-name-hyperzine: hyperzine
-reagent-desc-hyperzine: A highly-effective and long-lasting muscle stimulant.
+reagent-name-hyperzine = hyperzine
+reagent-desc-hyperzine = A highly-effective and long-lasting muscle stimulant.

--- a/Resources/Locale/en-US/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/reagents/meta/narcotics.ftl
@@ -39,3 +39,6 @@ reagent-desc-tear-gas = A chemical that causes severe irritation and crying, com
 
 reagent-name-happiness = happiness
 reagent-desc-happiness = Fills you with ecstatic numbness and causes minor brain damage. Highly addictive. If overdosed causes sudden mood swings.
+
+reagent-name-hyperzine: hyperzine
+reagent-desc-hyperzine: A highly-effective and long-lasting muscle stimulant.

--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -32,7 +32,7 @@ reagent-name-heartbreaker-toxin = heartbreaker toxin
 reagent-desc-heartbreaker-toxin = A hallucinogenic compound derived from mindbreaker toxin. it blocks neurological signals to the respiratory system, causing asphyxiation. Dexalin plus and epinephrine will filter it out, however.
 
 reagent-name-lexorin = lexorin
-reagent-desc-lexorin = A fast-acting chemical used to asphyxiate people rapidly.
+reagent-desc-lexorin = Lexorin temporarily stops respiration. Causes tissue damage.
 
 reagent-name-mindbreaker-toxin = mindbreaker toxin
 reagent-desc-mindbreaker-toxin = A potent, brain damaging poison that can remove psionics.
@@ -77,7 +77,7 @@ reagent-name-tazinide = tazinide
 reagent-desc-tazinide = A highly dangerous metallic mixture which can interfere with most movement through an electrifying current.
 
 reagent-name-lipolicide = lipolicide
-reagent-desc-lipolicide = A powerful toxin that will destroy fat cells, massively reducing body weight in a short time. Deadly to those without nutriment in their body.
+reagent-desc-lipolicide = A chemical compound that causes a powerful fat-burning reaction.
 
 reagent-name-soulbreaker-toxin = soulbreaker toxin
 reagent-desc-soulbreaker-toxin = An anti-psionic about 4 times as powerful as mindbreaker toxin.

--- a/Resources/Prototypes/Catalog/ReagentDispensers/chemical.yml
+++ b/Resources/Prototypes/Catalog/ReagentDispensers/chemical.yml
@@ -7,9 +7,7 @@
   - JugCopper
   - JugEthanol
   - JugFluorine
-  - JugSugar
   - JugHydrogen
-  - JugIodine
   - JugIron
   - JugLithium
   - JugMercury
@@ -18,9 +16,12 @@
   - JugPhosphorus
   - JugPotassium
   - JugRadium
-  - JugSilicon
+  - JugSulfuricAcid
   - JugSodium
+  - JugSilicon
+  - JugSugar
   - JugSulfur
+  - JugWater
 
 - type: reagentDispenserInventory
   id: EmptyInventory

--- a/Resources/Prototypes/Catalog/ReagentDispensers/chemical.yml
+++ b/Resources/Prototypes/Catalog/ReagentDispensers/chemical.yml
@@ -17,8 +17,8 @@
   - JugPotassium
   - JugRadium
   - JugSulfuricAcid
-  - JugSodium
   - JugSilicon
+  - JugSodium
   - JugSugar
   - JugSulfur
   - JugWater

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -418,3 +418,31 @@
           reagents:
             - ReagentId: WeldingFuel
               Quantity: 200
+
+- type: entity
+  parent: Jug
+  id: JugSulfuricAcid
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Label
+      currentLabel: reagent-name-sulfuric-acid
+    - type: SolutionContainerManager
+      solutions:
+        beaker:
+          reagents:
+            - ReagentId: SulfuricAcid
+              Quantity: 200
+
+- type: entity
+  parent: Jug
+  id: JugWater
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Label
+      currentLabel: reagent-name-water
+    - type: SolutionContainerManager
+      solutions:
+        beaker:
+          reagents:
+            - ReagentId: Water
+              Quantity: 200

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -457,7 +457,7 @@
   slippery: true
   physicalDesc: reagent-physical-desc-translucent
   flavor: water
-  color: "#75b1f0"
+  color: "#DEF7F5"
   recognizable: true
   boilingPoint: 100.0
   meltingPoint: 0.0

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -281,7 +281,7 @@
   desc: reagent-desc-diethylamine
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bitter
-  color: "#a1000b"
+  color: "#604030"
   boilingPoint: 55.5
   meltingPoint: -50.0
   plantMetabolism:

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -5,7 +5,7 @@
   desc: reagent-desc-aluminium # -we use real words here.
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
-  color: "#848789"
+  color: "#A8A8A8"
   boilingPoint: 2327.0
   meltingPoint: 660.0
 
@@ -16,7 +16,7 @@
   desc: reagent-desc-carbon
   physicalDesc: reagent-physical-desc-crystalline
   flavor: bitter
-  color: "#22282b"
+  color: "#1C1300"
   boilingPoint: 4200.0
   meltingPoint: 3550.0
 
@@ -27,18 +27,14 @@
   desc: reagent-desc-chlorine
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
-  color: "#a2ff00"
+  color: "#808080"
   meltingPoint: -101.5
   boilingPoint: -34.04
   plantMetabolism:
-    - !type:PlantAdjustWater
-      amount: -0.5
     - !type:PlantAdjustToxins
-      amount: 15
+      amount: 8
     - !type:PlantAdjustWeeds
-      amount: -3
-    - !type:PlantAdjustHealth
-      amount: -1
+      amount: -2
   metabolisms:
     Poison:
       effects:
@@ -54,7 +50,7 @@
   desc: reagent-desc-copper
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
-  color: "#b05b3c"
+  color: "#6E3B08"
   boilingPoint: 2595.0
   meltingPoint: 1083.0
   metabolisms:
@@ -85,7 +81,7 @@
   desc: reagent-desc-fluorine
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
-  color: "#ba85cc"
+  color: "#808080"
   boilingPoint: -188.11
   meltingPoint: -219.67
   plantMetabolism:
@@ -123,7 +119,7 @@
   desc: reagent-desc-hydrogen
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
-  color: "#cccccc"
+  color: "#808080"
   boilingPoint: -253.0
   meltingPoint: -259.2
 
@@ -176,7 +172,7 @@
   desc: reagent-desc-lithium
   physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
-  color: "#d6c0a7"
+  color: "#808080"
   meltingPoint: 180.5
   boilingPoint: 1330.0
   metabolisms:
@@ -203,7 +199,7 @@
   desc: reagent-desc-mercury
   physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
-  color: "#929296"
+  color: "#484848"
   meltingPoint: -38.83
   boilingPoint: 356.73
   metabolisms:
@@ -224,7 +220,7 @@
   desc: reagent-desc-potassium
   physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
-  color: "#c6c8cc"
+  color: "#A0A0A0"
   meltingPoint: 65.5
   boilingPoint: 759.0
 
@@ -235,7 +231,7 @@
   desc: reagent-desc-phosphorus
   physicalDesc: reagent-physical-desc-powdery
   flavor: metallic
-  color: "#f5da9a"
+  color: "#832828"
   meltingPoint: 44.2
   boilingPoint: 280.5
   plantMetabolism:
@@ -254,9 +250,13 @@
   desc: reagent-desc-radium
   physicalDesc: reagent-physical-desc-glowing
   flavor: metallic
-  color: "#00ff04"
+  color: "#61F09A"
   meltingPoint: 700.0
   boilingPoint: 1737.0
+  plantMetabolism:
+    - !type:PlantAdjustToxins
+      amount: 2
+      # TODO the great hydroponics genetics implementation
 
 - type: reagent
   id: Silicon
@@ -265,7 +265,7 @@
   desc: reagent-desc-silicon
   physicalDesc: reagent-physical-desc-crystalline
   flavor: metallic
-  color: "#364266"
+  color: "#A8A8A8"
   boilingPoint: 3265.0
   meltingPoint: 1414.0
   metabolisms:
@@ -294,7 +294,7 @@
   desc: reagent-desc-sulfur
   physicalDesc: reagent-physical-desc-powdery
   flavor: bitter
-  color: "#fff385"
+  color: "#BF8C00"
   boilingPoint: 445.0
   meltingPoint: 120.0
   metabolisms:
@@ -312,7 +312,7 @@
   desc: reagent-desc-sodium
   physicalDesc: reagent-physical-desc-metallic
   flavor: bitter
-  color: "#a7b3d6"
+  color: "#808080"
   meltingPoint: 97.8
   boilingPoint: 883.0
 
@@ -323,26 +323,16 @@
   desc: reagent-desc-uranium
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
-  color: "#8fa191"
+  color: "#B8B8C0"
   meltingPoint: 1133.0
   boilingPoint: 4131.0
-  plantMetabolism:
-  - !type:PlantAdjustMutationLevel
-    amount: 0.6
-  - !type:PlantAdjustToxins
-    amount: 4
-  - !type:PlantAdjustHealth
-    amount: -1.5
-  - !type:PlantAdjustMutationMod
-    probability: 0.2
-    amount: 0.1
   metabolisms:
     Poison:
       effects:
       - !type:HealthChange
         damage:
           types:
-            Radiation: 2
+            Radiation: 1
 
 - type: reagent
   id: Zinc

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -36,7 +36,7 @@
   desc: reagent-desc-dylovene
   physicalDesc: reagent-physical-desc-translucent
   flavor: medicine
-  color: "#3a1d8a"
+  color: "#C8A5DC"
   metabolisms:
     Medicine:
       effects:
@@ -108,7 +108,7 @@
   desc: reagent-desc-ethylredoxrazine
   physicalDesc: reagent-physical-desc-opaque
   flavor: medicine
-  color: "#2d5708"
+  color: "#605048"
   metabolisms:
     Medicine:
       effects:
@@ -128,7 +128,7 @@
   desc: reagent-desc-arithrazine
   physicalDesc: reagent-physical-desc-cloudy
   flavor: medicine
-  color: "#bd5902"
+  color: "#C8A5DC"
   metabolisms:
     Medicine:
       effects:
@@ -146,7 +146,7 @@
   desc: reagent-desc-bicaridine
   physicalDesc: reagent-physical-desc-opaque
   flavor: medicine
-  color: "#ffaa00"
+  color: "#5962F8"
   metabolisms:
     Medicine:
       effects:
@@ -180,7 +180,7 @@
   desc: reagent-desc-cryoxadone
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
-  color: "#0091ff"
+  color: "#C8A5DC"
   worksOnTheDead: true
   plantMetabolism:
   - !type:PlantAdjustToxins
@@ -232,7 +232,7 @@
   desc: reagent-desc-dermaline
   physicalDesc: reagent-physical-desc-translucent
   flavor: medicine
-  color: "#215263"
+  color: "#C8A5DC"
   metabolisms:
     Medicine:
       effects:
@@ -264,7 +264,7 @@
   desc: reagent-desc-dexalin
   physicalDesc: reagent-physical-desc-opaque
   flavor: medicine
-  color: "#0041a8"
+  color: "#4CE9FF"
   metabolisms:
     Medicine:
       effects:
@@ -289,7 +289,7 @@
   desc: reagent-desc-dexalin-plus
   physicalDesc: reagent-physical-desc-cloudy
   flavor: medicine
-  color: "#4da0bd"
+  color: "#4CE9FF"
   metabolisms:
     Medicine:
       effects:
@@ -383,7 +383,7 @@
   desc: reagent-desc-hyronalin
   physicalDesc: reagent-physical-desc-cloudy
   flavor: medicine
-  color: "#4cb580"
+  color: "#C8A5DC"
   metabolisms:
     Medicine:
       effects:
@@ -429,7 +429,7 @@
   desc: reagent-desc-inaprovaline
   physicalDesc: reagent-physical-desc-opaque
   flavor: medicine
-  color: "#731024"
+  color: "#C8A5DC"
   metabolisms:
     Medicine:
       effects:
@@ -451,7 +451,7 @@
   desc: reagent-desc-kelotane
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: medicine
-  color: "#bf3d19"
+  color: "#C2733F"
   metabolisms:
     Medicine:
       effects:
@@ -484,7 +484,7 @@
   desc: reagent-desc-leporazine
   physicalDesc: reagent-physical-desc-pungent
   flavor: medicine
-  color: "#ff7db5"
+  color: "#C8A5DC"
   metabolisms:
     Medicine:
       effects:
@@ -1397,3 +1397,175 @@
   - !type:PlantAdjustHealth
     amount: 0.1
 
+# /vg/med
+
+- type: reagent
+  id: Albuterol
+  name: reagent-name-albuterol
+  group: Medicine
+  desc: reagent-desc-albuterol
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Alkycosine
+  name: reagent-name-alkycosine
+  group: Medicine
+  desc: reagent-desc-alkycosine
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Alkysine
+  name: reagent-name-alkysine
+  group: Medicine
+  desc: reagent-desc-alkysine
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Biofoam
+  name: reagent-name-biofoam
+  group: Medicine
+  desc: reagent-desc-biofoam
+  physicalDesc: reagent-physical-desc-strong-smelling
+  flavor: medicine
+  color: "#D9C0E7"
+
+- type: reagent
+  id: Citalopram
+  name: reagent-name-citalopram
+  group: Medicine
+  desc: reagent-desc-citalopram
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Clonexadone
+  name: reagent-name-clonexadone
+  group: Medicine
+  desc: reagent-desc-clonexadone
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: ClottingAgent
+  name: reagent-name-clottingagent
+  group: Medicine
+  desc: reagent-desc-clottingagent
+  physicalDesc: reagent-physical-desc-grainy
+  flavor: medicine
+  color: "#a00000"
+
+- type: reagent
+  id: CombatNanobots
+  name: reagent-name-combatnanobots
+  group: Medicine
+  desc: reagent-desc-combatnanobots
+  physicalDesc: reagent-physical-desc-shiny
+  flavor: medicine
+  color: "#343F42"
+
+- type: reagent
+  id: DegenerateCalcium
+  name: reagent-name-degeneratecalcium
+  group: Medicine
+  desc: reagent-desc-degeneratecalcium
+  physicalDesc: reagent-physical-desc-cloudy
+  flavor: medicine
+  color: "#ccffb3"
+
+- type: reagent
+  id: Dietine
+  name: reagent-name-dietine
+  group: Medicine
+  desc: reagent-desc-dietine
+  physicalDesc: reagent-physical-desc-fizzy
+  flavor: medicine
+  color: "#BBEDA4"
+
+- type: reagent
+  id: Imidazoline
+  name: reagent-name-imidazoline
+  group: Medicine
+  desc: reagent-desc-imidazoline
+  physicalDesc: reagent-physical-desc-fizzy
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Inacusiate
+  name: reagent-name-inacusiate
+  group: Medicine
+  desc: reagent-desc-inacusiate
+  physicalDesc: reagent-physical-desc-opaque
+  flavor: medicine
+  color: "#6600FF"
+
+- type: reagent
+  id: Lithotorcrazine
+  name: reagent-name-lithotorcrazine
+  group: Medicine
+  desc: reagent-desc-lithotorcrazine
+  physicalDesc: reagent-physical-desc-thick-and-grainy
+  flavor: medicine
+  color: "#C0C0C0"
+
+- type: reagent
+  id: MedicalNanobots
+  name: reagent-name-medicalnanobots
+  group: Medicine
+  desc: reagent-desc-medicalnanobots
+  physicalDesc: reagent-physical-desc-shiny
+  flavor: medicine
+  color: "#593948"
+
+- type: reagent
+  id: Methylin
+  name: reagent-name-methylin
+  group: Medicine
+  desc: reagent-desc-methylin
+  physicalDesc: reagent-physical-desc-oily
+  flavor: medicine
+  color: "#CC1122"
+
+- type: reagent
+  id: Nanobots
+  name: reagent-name-nanobots
+  group: Medicine
+  desc: reagent-desc-nanobots
+  physicalDesc: reagent-physical-desc-shiny
+  flavor: medicine
+  color: "#3E3959"
+
+- type: reagent
+  id: Nanofloxacin
+  name: reagent-name-nanofloxacin
+  group: Medicine
+  desc: reagent-desc-nanofloxacin
+  physicalDesc: reagent-physical-desc-viscous
+  flavor: medicine
+  color: "#969696"
+
+- type: reagent
+  id: Spaceacillin
+  name: reagent-name-spaceacillin
+  group: Medicine
+  desc: reagent-name-spaceacillin
+  physicalDesc: reagent-physical-desc-grainy
+  flavor: medicine
+  color: "#C81040"
+
+- type: reagent
+  id: Tramadol
+  name: reagent-name-tramadol
+  group: Medicine
+  desc: reagent-desc-tramadol
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#C8A5DC"

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1553,13 +1553,148 @@
   color: "#969696"
 
 - type: reagent
+  id: Oxycodone
+  name: reagent-name-oxycodone
+  group: Medicine
+  desc: reagent-desc-oxycodone
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#C805DC"
+
+- type: reagent
+  id: Paracetamol
+  name: reagent-name-paracetamol
+  group: Medicine
+  desc: reagent-desc-paracetamol
+  physicalDesc: reagent-physical-desc-chalky
+  flavor: medicine
+  color: "#C855DC"
+
+- type: reagent
+  id: Paroxetine
+  name: reagent-name-paroxetine
+  group: Medicine
+  desc: reagent-desc-paroxetine
+  physicalDesc: reagent-physical-desc-fizzy
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Peptobismol
+  name: reagent-name-peptobismol
+  group: Medicine
+  desc: reagent-desc-peptobismol
+  physicalDesc: reagent-physical-desc-cloudy
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Peridaxon
+  name: reagent-name-peridaxon
+  group: Medicine
+  desc: reagent-desc-peridaxon
+  physicalDesc: reagent-physical-desc-strong-smelling
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Piccolyn
+  name: reagent-name-piccolyn
+  group: Medicine
+  desc: reagent-desc-piccolyn
+  physicalDesc: reagent-physical-desc-soothing
+  flavor: medicine
+  color: "#00FF00"
+
+- type: reagent
+  id: Preslomite
+  name: reagent-name-preslomite
+  group: Medicine
+  desc: reagent-desc-preslomite
+  physicalDesc: reagent-physical-desc-fizzy
+  flavor: medicine
+  color: "#FFFFFF"
+
+- type: reagent
+  id: Priaxate
+  name: reagent-name-priaxate
+  group: Medicine
+  desc: reagent-desc-priaxate
+  physicalDesc: reagent-physical-desc-pungent
+  flavor: medicine
+  color: "#CD8471"
+
+- type: reagent
+  id: Rezadone
+  name: reagent-name-rezadone
+  group: Medicine
+  desc: reagent-desc-rezadone
+  physicalDesc: reagent-physical-desc-inky
+  flavor: medicine
+  color: "#669900"
+
+- type: reagent
+  id: Ryetalyn
+  name: reagent-name-ryetalyn
+  group: Medicine
+  desc: reagent-desc-ryetalyn
+  physicalDesc: reagent-physical-desc-odorless
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Simpolinol
+  name: reagent-name-simpolinol
+  group: Medicine
+  desc: reagent-desc-simpolinol
+  physicalDesc: reagent-physical-desc-fizzy
+  flavor: medicine
+  color: "#A5A5FF"
+
+- type: reagent
+  id: SoporificRejuvenant
+  name: reagent-name-soporificrejuvenant
+  group: Medicine
+  desc: reagent-desc-soporificrejuvenant
+  physicalDesc: reagent-physical-desc-cloudy
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
   id: Spaceacillin
   name: reagent-name-spaceacillin
   group: Medicine
-  desc: reagent-name-spaceacillin
+  desc: reagent-desc-spaceacillin
   physicalDesc: reagent-physical-desc-grainy
   flavor: medicine
   color: "#C81040"
+
+- type: reagent
+  id: Stabilizine
+  name: reagent-name-stabilizine
+  group: Medicine
+  desc: reagent-desc-stabilizine
+  physicalDesc: reagent-physical-desc-opaque
+  flavor: medicine
+  color: "#833484"
+
+- type: reagent
+  id: Sterilizine
+  name: reagent-name-sterilizine
+  group: Medicine
+  desc: reagent-desc-sterilizine
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#C8A5DC"
+
+- type: reagent
+  id: Synthocarisol
+  name: reagent-name-synthocarisol
+  group: Medicine
+  desc: reagent-desc-synthocarisol
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#580082"
 
 - type: reagent
   id: Tramadol
@@ -1569,3 +1704,12 @@
   physicalDesc: reagent-physical-desc-translucent
   flavor: medicine
   color: "#C8A5DC"
+
+- type: reagent
+  id: Trinitrine
+  name: reagent-name-trinitrine
+  group: Medicine
+  desc: reagent-desc-trinitrine
+  physicalDesc: reagent-physical-desc-oily
+  flavor: medicine
+  color: "#CED7D5"

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -478,3 +478,14 @@
         type: Add
         time: 5
         refresh: false
+
+- type: reagent
+  id: Hyperzine
+  name: reagent-name-hyperzine
+  group: Narcotics
+  desc: reagent-desc-hyperzine
+  physicalDesc: reagent-physical-desc-fizzy
+  flavor: bitter
+  color: "#DCDCDC"
+  boilingPoint: 100.0
+  meltingPoint: 0.0

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -318,7 +318,7 @@
   group: Toxins
   desc: reagent-desc-lexorin
   physicalDesc: reagent-physical-desc-pungent
-  color: "#6b0007"
+  color: "#C8A5DC"
   metabolisms:
     Poison:
       effects:

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -6,7 +6,7 @@
     Nitrogen:
       amount: 1
   products:
-    Ammonia: 4
+    Ammonia: 3
 
 - type: reaction
   id: CelluloseBreakdown
@@ -81,7 +81,7 @@
       amount: 1
     Sulfur:
       amount: 1
-    Oxygen: 
+    Oxygen:
       amount: 2
   products:
     SulfuricAcid: 3
@@ -501,3 +501,5 @@
       amount: 1
   products:
     Tazinide: 1
+
+#/vg/ chems

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -501,5 +501,3 @@
       amount: 1
   products:
     Tazinide: 1
-
-#/vg/ chems

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -108,10 +108,10 @@
     Oxygen:
       amount: 2
     Plasma:
-      amount: 1
+      amount: 5
       catalyst: true
   products:
-    Dexalin: 3
+    Dexalin: 1
 
 - type: reaction
   id: DexalinPlus
@@ -186,10 +186,10 @@
   reactants:
     Copper:
       amount: 1
-    Fersilicite:
+    Silicon:
       amount: 1
     Plasma:
-      amount: 1
+      amount: 5
       catalyst: true
   products:
     Leporazine: 2
@@ -279,14 +279,12 @@
   id: Lexorin
   impact: High
   reactants:
-    HeartbreakerToxin:
-      amount: 1
     Plasma:
-      amount: 3
-    Impedrezene:
-      amount: 3
+      amount: 1
+    Ammonia:
+      amount: 1
   products:
-    Lexorin: 2
+    Lexorin: 3
 
 - type: reaction
   id: Lipozine
@@ -666,3 +664,227 @@
       amount: 1
   products:
     Haloperidol: 5
+
+# /vg/med
+
+- type: reaction
+  id: Albuterol
+  reactants:
+    Tramadol:
+      amount: 1
+    Hyperzine:
+      amount: 1
+  products:
+    Albuterol: 2
+
+- type: reaction
+  id: Alkycosine
+  reactants:
+    Alkysine:
+      amount: 1
+    Bleach:
+      amount: 1
+    Dylovene:
+      amount: 1
+  products:
+    Alkycosine:
+      amount: 4
+
+- type: reaction
+  id: Alkysine
+  reactants:
+    Chlorine:
+      amount: 1
+    Nitrogen:
+      amount: 1
+    Dylovene:
+      amount: 1
+  products:
+    Alkysine:
+      amount: 2
+  minTemp: 40
+
+- type: reaction
+  id: Citalopram
+  reactants:
+    MindbreakerToxin:
+      amount: 1
+    Carbon:
+      amount: 1
+  products:
+    Citalopram:
+      amount: 3
+
+- type: reaction
+  id: Clonexadone
+  reactants:
+    Cryoxadone:
+      amount: 1
+    Sodium:
+      amount: 1
+    Plasma:
+      amount: 5
+      catalyst: true
+  products:
+    Clonexadone:
+      amount: 2
+
+- type: reaction
+  id: CombatNanobots
+  reactants:
+    Nanobots:
+      amount: 1
+    UnstableMutagen:
+      amount: 5
+    Silicate:
+      amount: 5
+    Iron:
+      amount: 10
+  products:
+    CombatNanobots:
+      amount: 2.5
+
+- type: reaction
+  id: DegenerateCalcium
+  reactants:
+    Milk:
+      amount: 1
+    UnstableMutagen:
+      amount: 1
+  products:
+    DegenerateCalcium:
+      amount: 1
+  minTemp: 88
+
+- type: reaction
+  id: Dietine
+  reactants:
+    TableSalt:
+      amount: 1
+    Coffee:
+      amount: 3
+    Lithium:
+      amount: 1
+    WeldingFuel:
+      amount: 1
+  products:
+    Dietine:
+      amount: 1
+
+- type: reaction
+  id: Imidazoline
+  reactants:
+    Carbon:
+      amount: 1
+    Hydrogen:
+      amount: 1
+    Dylovene:
+      amount: 1
+  products:
+    Imidazoline:
+      amount: 2
+
+- type: reaction
+  id: Lithotorcrazine
+  reactants:
+    Lithium:
+      amount: 1
+    Arithrazine:
+      amount: 3
+    Uranium:
+      amount: 1
+  products:
+    Lithotorcrazine:
+      amount: 5
+
+- type: reaction
+  id: MedicalNanobots
+  reactants:
+    Nanobots:
+      amount: 1
+    DoctorsDelight:
+      amount: 5
+  products:
+    MedicalNanobots:
+      amount: 2.5
+
+- type: reaction
+  id: Methylin
+  reactants:
+    Hydrogen:
+      amount: 1
+    Chlorine:
+      amount: 1
+    Ethanol:
+      amount: 1
+    Fluorine:
+      amount: 5
+      catalyst: true
+  products:
+    Methylin:
+      amount: 1
+
+- type: reaction
+  id: Nanobots
+  reactants:
+    Nanites:
+      amount: 1
+    Uranium:
+      amount: 10
+    Gold:
+      amount: 10
+    Nutriment:
+      amount: 10
+    Silicon:
+      amount: 10
+  products:
+    Nanobots:
+      amount: 2
+
+- type: reaction
+  id: Nanobots2
+  reactants:
+    MedicalNanobots:
+      amount: 2.5
+    Cryoxadone:
+      amount: 2
+  products:
+    Nanobots:
+      amount: 1
+
+- type: reaction
+  id: Nanofloxacin
+  reactants:
+    Nanobots:
+      amount: 1
+    Spaceacillin:
+      amount: 5
+    Fluorine:
+      amount: 1
+  products:
+    Nanofloxacin:
+      amount: 2.5
+
+- type: reaction
+  id: Spaceacillin
+  reactants:
+    Cryptobiolin:
+      amount: 1
+    Inaprovaline:
+      amount: 1
+  products:
+    Spaceacillin:
+      amount: 2
+
+- type: reaction
+  id: Tramadol
+  reactants:
+    Inaprovaline:
+      amount: 1
+    Ethanol:
+      amount: 1
+    Oxygen:
+      amount: 1
+  products:
+    Tramadol:
+      amount: 3

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -687,8 +687,7 @@
     Dylovene:
       amount: 1
   products:
-    Alkycosine:
-      amount: 4
+    Alkycosine: 4
 
 - type: reaction
   id: Alkysine
@@ -700,8 +699,7 @@
     Dylovene:
       amount: 1
   products:
-    Alkysine:
-      amount: 2
+    Alkysine: 2
   minTemp: 40
 
 - type: reaction
@@ -712,8 +710,7 @@
     Carbon:
       amount: 1
   products:
-    Citalopram:
-      amount: 3
+    Citalopram: 3
 
 - type: reaction
   id: Clonexadone
@@ -726,8 +723,7 @@
       amount: 5
       catalyst: true
   products:
-    Clonexadone:
-      amount: 2
+    Clonexadone: 2
 
 - type: reaction
   id: CombatNanobots
@@ -741,8 +737,7 @@
     Iron:
       amount: 10
   products:
-    CombatNanobots:
-      amount: 2.5
+    CombatNanobots: 2.5
 
 - type: reaction
   id: DegenerateCalcium
@@ -752,8 +747,7 @@
     UnstableMutagen:
       amount: 1
   products:
-    DegenerateCalcium:
-      amount: 1
+    DegenerateCalcium: 1
   minTemp: 88
 
 - type: reaction
@@ -768,8 +762,7 @@
     WeldingFuel:
       amount: 1
   products:
-    Dietine:
-      amount: 1
+    Dietine: 1
 
 - type: reaction
   id: Imidazoline
@@ -781,8 +774,7 @@
     Dylovene:
       amount: 1
   products:
-    Imidazoline:
-      amount: 2
+    Imidazoline: 2
 
 - type: reaction
   id: Lithotorcrazine
@@ -794,8 +786,7 @@
     Uranium:
       amount: 1
   products:
-    Lithotorcrazine:
-      amount: 5
+    Lithotorcrazine: 5
 
 - type: reaction
   id: MedicalNanobots
@@ -805,8 +796,7 @@
     DoctorsDelight:
       amount: 5
   products:
-    MedicalNanobots:
-      amount: 2.5
+    MedicalNanobots: 2.5
 
 - type: reaction
   id: Methylin
@@ -821,8 +811,7 @@
       amount: 5
       catalyst: true
   products:
-    Methylin:
-      amount: 1
+    Methylin: 1
 
 - type: reaction
   id: Nanobots
@@ -838,8 +827,7 @@
     Silicon:
       amount: 10
   products:
-    Nanobots:
-      amount: 2
+    Nanobots: 2
 
 - type: reaction
   id: Nanobots2
@@ -849,8 +837,7 @@
     Cryoxadone:
       amount: 2
   products:
-    Nanobots:
-      amount: 1
+    Nanobots: 1
 
 - type: reaction
   id: Nanofloxacin
@@ -862,8 +849,95 @@
     Fluorine:
       amount: 1
   products:
-    Nanofloxacin:
-      amount: 2.5
+    Nanofloxacin: 2.5
+
+- type: reaction
+  id: Oxycodone
+  reactants:
+    Ethanol:
+      amount: 1
+    Tramadol:
+      amount: 1
+    Plasma:
+      amount: 1
+  products:
+    Oxycodone: 3
+
+- type: reaction
+  id: Paroxetine
+  reactants:
+    MindbreakerToxin:
+      amount: 1
+    Oxygen:
+      amount: 1
+    Inaprovaline:
+      amount: 1
+  products:
+    Paroxetine: 3
+
+- type: reaction
+  id: Peptobismol
+  reactants:
+    Dylovene:
+      amount: 1
+    DiscountDansSpecialSauce:
+      amount: 1
+  products:
+    Peptobismol: 2
+
+- type: reaction
+  id: Piccolyn
+  reactants:
+    Copper:
+      amount: 1
+    Tungsten:
+      amount: 1
+    Fluorine:
+      amount: 1
+  products:
+    Piccolyn: 1
+
+- type: reaction
+  id: Priaxate
+  reactants:
+    Gravy:
+      amount: 1
+    Tricordrazine:
+      amount: 1
+  products:
+    Priaxate: 2
+
+- type: reaction
+  id: Rezadone
+  reactants:
+    CarpoToxin:
+      amount: 1
+    Cryptobiolin:
+      amount: 1
+    Copper:
+      amount: 1
+  products:
+    Rezadone: 3
+
+- type: reaction
+  id: Ryetalyn
+  reactants:
+    Arithrazine:
+      amount: 1
+    Carbon:
+      amount: 1
+  products:
+    Ryetalyn: 2
+
+- type: reaction
+  id: Simpolinol
+  reactants:
+    Methylin:
+      amount: 20
+    Silver:
+      amount: 20
+  products:
+    Simpolinol: 40
 
 - type: reaction
   id: Spaceacillin
@@ -873,8 +947,30 @@
     Inaprovaline:
       amount: 1
   products:
-    Spaceacillin:
-      amount: 2
+    Spaceacillin: 2
+
+- type: reaction
+  id: Sterilizine
+  reactants:
+    Ethanol:
+      amount: 1
+    Dylovene:
+      amount: 1
+    Chlorine:
+      amount: 1
+  products:
+    Sterilizine: 3
+
+- type: reaction
+  id: Synthocarisol
+  reactants:
+    Bicaridine:
+      amount: 1
+    Inaprovaline:
+      amount: 1
+  products:
+    Synthocarisol: 2
+  minTemp: 77
 
 - type: reaction
   id: Tramadol
@@ -886,5 +982,19 @@
     Oxygen:
       amount: 1
   products:
-    Tramadol:
+    Tramadol: 3
+
+- type: reaction
+  id: Trinitrine
+  reactants:
+    Glycerol:
+      amount: 1
+    SulfuricAcid:
+      amount: 1
+    Water:
       amount: 3
+    Nitrogen:
+      amount: 5
+      catalyst: true
+  products:
+    Trinitrine: 5


### PR DESCRIPTION
Addresses part of #46 

- Adds reagent prototypes and recipes for (most) missing meds (see new additions in medicine.yml)
  - None of the chems do anything yet. Behaviours to come later as other code is added, see below
- Slight tweaks to only a couple of existing meds, goes beyond this PR but I got drunk and tired and did a driveby edit
  - Also tweaks the atrocious use of English on a couple of descriptions for the same reason
- Change chem dispenser to our loadout. Also removes automatic alphabetising of reagents so you can use some of your existing muscle memory
  - Tungsten not yet added, something called tungsten exists in the code but it seems only as a material rather than a reagent

Todos:
- Add Tungsten (for Piccoline) reagent
- Add Discount Dan's Special Sauce (for Peptobismol) reagent
- Add Gravy (for Priaxate) reagent

Todo in #64 :
- Add relevant behaviours to new chems as far as is possible
  - eg. Alkysine needs to fix brain damage, which is not yet in
- Match existing chem behaviours
  - Adjust damage modifiers and other effects where they diverge from our behaviour

Todo in another PR eventually:
- Chem dispenser to charge from APC rather than rely on replenishing reagents manually? See what players think in test